### PR TITLE
Makes rule work for non https urls

### DIFF
--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -276,7 +276,7 @@ parseSubTarget match =
 
 linkRegex : Regex
 linkRegex =
-    Regex.fromString "https://package\\.elm-lang\\.org/packages/([\\w-]+/[\\w-]+)/(latest|\\w+\\.\\w+\\.\\w+)(/(.*))?"
+    Regex.fromString "https?://package\\.elm-lang\\.org/packages/([\\w-]+/[\\w-]+)/(latest|\\w+\\.\\w+\\.\\w+)(/(.*))?"
         |> Maybe.withDefault Regex.never
 
 


### PR DESCRIPTION
If you are enabling this on a project of a certain vintage, chances are Docs.UpToDateReadmeLinks won't work, because you likely have links that start with `http://package.elm-lang.org/` because you copy-pasted the link from the docs site before it supported HTTPS.

So this tiny change makes the regex slightly more permissive and finds these old style links as well.