### PR TITLE
Absolute path URLs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ elm-stuff/
 node_modules/
 .idea/
 ElmjutsuDumMyM0DuL3.elm
+.vscode/

--- a/elm.json
+++ b/elm.json
@@ -16,6 +16,7 @@
         "elm/parser": "1.1.0 <= v < 2.0.0",
         "elm/project-metadata-utils": "1.0.2 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
+        "elm/url": "1.0.0 <= v < 2.0.0",
         "jfmengels/elm-review": "2.10.0 <= v < 3.0.0",
         "stil4m/elm-syntax": "7.2.9 <= v < 8.0.0"
     },

--- a/review/elm.json
+++ b/review/elm.json
@@ -12,6 +12,7 @@
             "elm/parser": "1.1.0",
             "elm/project-metadata-utils": "1.0.2",
             "elm/regex": "1.0.0",
+            "elm/url": "1.0.0",
             "jfmengels/elm-review": "2.10.0",
             "jfmengels/elm-review-code-style": "1.1.2",
             "jfmengels/elm-review-cognitive-complexity": "1.0.0",

--- a/src/Docs/ReviewLinksAndSections.elm
+++ b/src/Docs/ReviewLinksAndSections.elm
@@ -125,6 +125,7 @@ rule =
     Rule.newProjectRuleSchema "Docs.ReviewLinksAndSections" initialProjectContext
         |> Rule.withElmJsonProjectVisitor elmJsonVisitor
         |> Rule.withReadmeProjectVisitor readmeVisitor
+        |> Rule.providesFixesForProjectRule
         |> Rule.withModuleVisitor moduleVisitor
         |> Rule.withModuleContextUsingContextCreator
             { fromProjectToModule = fromProjectToModule

--- a/src/Docs/ReviewLinksAndSections.elm
+++ b/src/Docs/ReviewLinksAndSections.elm
@@ -639,6 +639,7 @@ reportErrorsForPackagesTarget projectContext sectionsPerModule fileLinksAndSecti
                     { name = name
                     , subTarget = subTarget
                     , slug = maybeExposedLink.link.slug
+                    , absolutePath = False
                     }
                 )
 
@@ -650,6 +651,7 @@ reportErrorsForPackagesTarget projectContext sectionsPerModule fileLinksAndSecti
                     { name = name
                     , subTarget = subTarget
                     , slug = maybeExposedLink.link.slug
+                    , absolutePath = False
                     }
                 )
 
@@ -807,7 +809,7 @@ reportLinkToExternalResourceWithoutProtocol fileKey range =
 reportAbsolutePathLinkFromReadmeToPackage :
     Rule.ReadmeKey
     -> Range
-    -> { name : String, subTarget : Link.SubTarget, slug : Maybe String }
+    -> { name : String, subTarget : Link.SubTarget, slug : Maybe String, absolutePath : Bool }
     -> Rule.Error scope
 reportAbsolutePathLinkFromReadmeToPackage readmeKey range linkInfo =
     Rule.errorForReadmeWithFix readmeKey
@@ -824,7 +826,7 @@ reportAbsolutePathLinkFromReadmeToPackage readmeKey range linkInfo =
 reportAbsolutePathLinkInAppProject :
     FileKey
     -> Range
-    -> { name : String, subTarget : Link.SubTarget, slug : Maybe String }
+    -> { name : String, subTarget : Link.SubTarget, slug : Maybe String, absolutePath : Bool }
     -> Rule.Error scope
 reportAbsolutePathLinkInAppProject fileKey range linkInfo =
     reportForFileWithFix fileKey

--- a/src/Docs/ReviewLinksAndSections.elm
+++ b/src/Docs/ReviewLinksAndSections.elm
@@ -634,6 +634,7 @@ reportErrorsForPackagesTarget projectContext sectionsPerModule fileLinksAndSecti
         ( Just currentPackage, _ ) ->
             -- Package project
             let
+                version : Maybe String
                 version =
                     Link.subTargetVersion subTarget
             in
@@ -662,10 +663,10 @@ reportErrorsForPackagesTarget projectContext sectionsPerModule fileLinksAndSecti
 reportErrorForCurrentPackageSubTarget : ProjectContext -> Dict ModuleName (List Section) -> FileLinksAndSections -> MaybeExposedLinkData -> Link.SubTarget -> Maybe (Rule.Error scope)
 reportErrorForCurrentPackageSubTarget projectContext sectionsPerModule fileLinksAndSections maybeExposedLink subTarget =
     case subTarget of
-        Link.ModuleSubTarget version moduleName ->
+        Link.ModuleSubTarget _ moduleName ->
             reportErrorForModule projectContext sectionsPerModule fileLinksAndSections maybeExposedLink moduleName
 
-        Link.ReadmeSubTarget version ->
+        Link.ReadmeSubTarget _ ->
             reportErrorForReadme sectionsPerModule fileLinksAndSections.fileKey maybeExposedLink
 
         Link.VersionsSubTarget ->

--- a/src/Docs/ReviewLinksAndSections.elm
+++ b/src/Docs/ReviewLinksAndSections.elm
@@ -631,18 +631,6 @@ errorForFile projectContext sectionsPerModule fileLinksAndSections (MaybeExposed
 reportErrorsForPackagesTarget : ProjectContext -> Dict ModuleName (List Section) -> FileLinksAndSections -> MaybeExposedLinkData -> { name : String, subTarget : Link.SubTarget } -> Maybe (Rule.Error scope)
 reportErrorsForPackagesTarget projectContext sectionsPerModule fileLinksAndSections maybeExposedLink { name, subTarget } =
     case ( projectContext.packageNameAndVersion, maybeExposedLink.link.startsWith ) of
-        ( Nothing, Link.StartsWithSlash ) ->
-            -- App project with absolute-path link
-            Just
-                (reportAbsolutePathLinkInAppProject fileLinksAndSections.fileKey
-                    maybeExposedLink.linkRange
-                    { name = name
-                    , subTarget = subTarget
-                    , slug = maybeExposedLink.link.slug
-                    , absolutePath = False
-                    }
-                )
-
         ( Just currentPackage, _ ) ->
             -- Package project
             let
@@ -654,6 +642,18 @@ reportErrorsForPackagesTarget projectContext sectionsPerModule fileLinksAndSecti
 
             else
                 Nothing
+
+        ( Nothing, Link.StartsWithSlash ) ->
+            -- App project with absolute-path link
+            Just
+                (reportAbsolutePathLinkInAppProject fileLinksAndSections.fileKey
+                    maybeExposedLink.linkRange
+                    { name = name
+                    , subTarget = subTarget
+                    , slug = maybeExposedLink.link.slug
+                    , absolutePath = False
+                    }
+                )
 
         _ ->
             Nothing

--- a/src/Docs/ReviewLinksAndSections.elm
+++ b/src/Docs/ReviewLinksAndSections.elm
@@ -630,15 +630,7 @@ reportErrorsForPackagesTarget : ProjectContext -> Dict ModuleName (List Section)
 reportErrorsForPackagesTarget projectContext sectionsPerModule fileLinksAndSections maybeExposedLink { name, subTarget } =
     let
         version =
-            case subTarget of
-                Link.ReadmeSubTarget ver ->
-                    Just ver
-
-                Link.ModuleSubTarget ver _ ->
-                    Just ver
-
-                _ ->
-                    Nothing
+            Link.subTargetVersion subTarget
     in
     case projectContext.packageNameAndVersion of
         Just currentPackage ->

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -182,6 +182,9 @@ formatSubTargetWithVersion version subTarget =
         Link.ModuleSubTarget _ moduleName ->
             version ++ "/" ++ String.join "-" moduleName ++ "/"
 
+        Link.ReadmeSubTarget _ ->
+            version ++ "/"
+
         _ ->
             ""
 

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -175,10 +175,10 @@ reportError context readmeKey (Node range link) =
 
             else if link.startsWith == Link.StartsWithSlash then
                 [ Rule.errorForReadmeWithFix readmeKey
-                    { message = "Readme link uses an absolute-path"
+                    { message = "README link uses an absolute-path"
                     , details =
-                        [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
-                        , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
+                        [ "Links starting with \"/\" don't work when looking at the docs from GitHub or the likes."
+                        , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."
                         ]
                     }
                     range

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -149,6 +149,7 @@ reportError context readmeKey (Node range link) =
 
         Link.PackagesTarget { name, subTarget } ->
             let
+                linkVersion : Maybe String
                 linkVersion =
                     Link.subTargetVersion subTarget
             in

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -160,7 +160,11 @@ reportError context readmeKey (Node range link) =
                     range
                     [ Fix.replaceRangeBy range
                         (Link.formatPackageLinkForVersion (Just context.version)
-                            { name = name, subTarget = subTarget, slug = link.slug }
+                            { name = name
+                            , subTarget = subTarget
+                            , slug = link.slug
+                            , absolutePath = link.startsWith == Link.StartsWithSlash
+                            }
                         )
                     ]
                 ]

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -126,7 +126,7 @@ reportError context readmeKey (Node range link) =
             ]
 
         Link.ReadmeTarget ->
-            if link.linkStartsWith == Link.LinkStartsWithDotSlash then
+            if link.startsWith == Link.StartsWithDotSlash then
                 [ Rule.errorForReadmeWithFix readmeKey
                     { message = "Found relative link from and to README"
                     , details =
@@ -173,7 +173,7 @@ reportError context readmeKey (Node range link) =
                     ]
                 ]
 
-            else if link.linkStartsWith == Link.LinkStartsWithSlash then
+            else if link.startsWith == Link.StartsWithSlash then
                 [ Rule.errorForReadmeWithFix readmeKey
                     { message = "Readme link uses an absolute-path"
                     , details =

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -160,20 +160,7 @@ reportError context readmeKey (Node range link) =
                         Link.VersionsSubTarget ->
                             Nothing
             in
-            if context.projectName == name && Just context.version /= version then
-                [ Rule.errorForReadmeWithFix readmeKey
-                    { message = "Link does not point to the current version of the package"
-                    , details = [ "I suggest to run elm-review --fix to get the correct link." ]
-                    }
-                    range
-                    [ Fix.replaceRangeBy range
-                        (formatPackageLinkForVersion context.version
-                            { name = name, subTarget = subTarget, slug = link.slug }
-                        )
-                    ]
-                ]
-
-            else if link.startsWith == Link.StartsWithSlash then
+            if link.startsWith == Link.StartsWithSlash then
                 [ Rule.errorForReadmeWithFix readmeKey
                     { message = "README link uses an absolute-path"
                     , details =
@@ -184,6 +171,19 @@ reportError context readmeKey (Node range link) =
                     range
                     [ Fix.replaceRangeBy range
                         (formatPackageLinkForVersion (Maybe.withDefault "" version)
+                            { name = name, subTarget = subTarget, slug = link.slug }
+                        )
+                    ]
+                ]
+
+            else if context.projectName == name && Just context.version /= version then
+                [ Rule.errorForReadmeWithFix readmeKey
+                    { message = "Link does not point to the current version of the package"
+                    , details = [ "I suggest to run elm-review --fix to get the correct link." ]
+                    }
+                    range
+                    [ Fix.replaceRangeBy range
+                        (formatPackageLinkForVersion context.version
                             { name = name, subTarget = subTarget, slug = link.slug }
                         )
                     ]

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -166,7 +166,11 @@ reportError context readmeKey (Node range link) =
                     , details = [ "I suggest to run elm-review --fix to get the correct link." ]
                     }
                     range
-                    [ Fix.replaceRangeBy range (formatPackageLink { name = name, version = context.version, subTarget = subTarget, slug = link.slug }) ]
+                    [ Fix.replaceRangeBy range
+                        (formatPackageLinkForVersion context.version
+                            { name = name, subTarget = subTarget, slug = link.slug }
+                        )
+                    ]
                 ]
 
             else if link.linkStartsWith == Link.LinkStartsWithSlash then
@@ -178,7 +182,11 @@ reportError context readmeKey (Node range link) =
                         ]
                     }
                     range
-                    [ Fix.replaceRangeBy range (formatPackageLink { name = name, version = Maybe.withDefault "" version, subTarget = subTarget, slug = link.slug }) ]
+                    [ Fix.replaceRangeBy range
+                        (formatPackageLinkForVersion (Maybe.withDefault "" version)
+                            { name = name, subTarget = subTarget, slug = link.slug }
+                        )
+                    ]
                 ]
 
             else
@@ -188,17 +196,17 @@ reportError context readmeKey (Node range link) =
             []
 
 
-formatPackageLink : { name : String, version : String, subTarget : Link.SubTarget, slug : Maybe String } -> String
-formatPackageLink { name, version, subTarget, slug } =
+formatPackageLinkForVersion : String -> { name : String, subTarget : Link.SubTarget, slug : Maybe String } -> String
+formatPackageLinkForVersion version { name, subTarget, slug } =
     "https://package.elm-lang.org/packages/"
         ++ name
         ++ "/"
-        ++ formatSubTargetWithVersion version subTarget
+        ++ formatSubTargetForVersion version subTarget
         ++ formatSlug slug
 
 
-formatSubTargetWithVersion : String -> Link.SubTarget -> String
-formatSubTargetWithVersion version subTarget =
+formatSubTargetForVersion : String -> Link.SubTarget -> String
+formatSubTargetForVersion version subTarget =
     case subTarget of
         Link.ModuleSubTarget _ moduleName ->
             version ++ "/" ++ String.join "-" moduleName ++ "/"

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -126,7 +126,7 @@ reportError context readmeKey (Node range link) =
             ]
 
         Link.ReadmeTarget ->
-            if link.startsWithDotSlash then
+            if link.linkStartsWith == Link.LinkStartsWithDotSlash then
                 [ Rule.errorForReadmeWithFix readmeKey
                     { message = "Found relative link from and to README"
                     , details =

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -152,23 +152,7 @@ reportError context readmeKey (Node range link) =
                 linkVersion =
                     Link.subTargetVersion subTarget
             in
-            if link.startsWith == Link.StartsWithSlash then
-                [ Rule.errorForReadmeWithFix readmeKey
-                    { message = "README link uses an absolute-path"
-                    , details =
-                        [ "Links starting with \"/\" don't work when looking at the docs from GitHub or the likes."
-                        , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."
-                        ]
-                    }
-                    range
-                    [ Fix.replaceRangeBy range
-                        (Link.formatPackageLinkForVersion linkVersion
-                            { name = name, subTarget = subTarget, slug = link.slug }
-                        )
-                    ]
-                ]
-
-            else if context.projectName == name && Just context.version /= linkVersion then
+            if context.projectName == name && Just context.version /= linkVersion then
                 [ Rule.errorForReadmeWithFix readmeKey
                     { message = "Link does not point to the current version of the package"
                     , details = [ "I suggest to run elm-review --fix to get the correct link." ]

--- a/src/Docs/UpToDateReadmeLinks.elm
+++ b/src/Docs/UpToDateReadmeLinks.elm
@@ -122,7 +122,7 @@ reportError context readmeKey (Node range link) =
                     ]
                 }
                 range
-                [ Fix.replaceRangeBy range <| "https://package.elm-lang.org/packages/" ++ context.projectName ++ "/" ++ context.version ++ "/" ++ String.join "-" moduleName ++ formatSlug link.slug ]
+                [ Fix.replaceRangeBy range <| "https://package.elm-lang.org/packages/" ++ context.projectName ++ "/" ++ context.version ++ "/" ++ String.join "-" moduleName ++ Link.formatSlug link.slug ]
             ]
 
         Link.ReadmeTarget ->
@@ -162,7 +162,7 @@ reportError context readmeKey (Node range link) =
                     }
                     range
                     [ Fix.replaceRangeBy range
-                        (formatPackageLinkForVersion linkVersion
+                        (Link.formatPackageLinkForVersion linkVersion
                             { name = name, subTarget = subTarget, slug = link.slug }
                         )
                     ]
@@ -175,7 +175,7 @@ reportError context readmeKey (Node range link) =
                     }
                     range
                     [ Fix.replaceRangeBy range
-                        (formatPackageLinkForVersion (Just context.version)
+                        (Link.formatPackageLinkForVersion (Just context.version)
                             { name = name, subTarget = subTarget, slug = link.slug }
                         )
                     ]
@@ -186,40 +186,3 @@ reportError context readmeKey (Node range link) =
 
         Link.External _ ->
             []
-
-
-formatPackageLinkForVersion : Maybe String -> { name : String, subTarget : Link.SubTarget, slug : Maybe String } -> String
-formatPackageLinkForVersion versionMaybe { name, subTarget, slug } =
-    "https://package.elm-lang.org/packages/"
-        ++ name
-        ++ "/"
-        ++ formatSubTargetForVersion versionMaybe subTarget
-        ++ formatSlug slug
-
-
-formatSubTargetForVersion : Maybe String -> Link.SubTarget -> String
-formatSubTargetForVersion versionMaybe subTarget =
-    case versionMaybe of
-        Just version ->
-            case subTarget of
-                Link.ModuleSubTarget _ moduleName ->
-                    version ++ "/" ++ String.join "-" moduleName ++ "/"
-
-                Link.ReadmeSubTarget _ ->
-                    version ++ "/"
-
-                Link.VersionsSubTarget ->
-                    ""
-
-        Nothing ->
-            ""
-
-
-formatSlug : Maybe String -> String
-formatSlug maybeSlug =
-    case maybeSlug of
-        Just slug ->
-            "#" ++ slug
-
-        Nothing ->
-            ""

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -14,7 +14,7 @@ import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Range exposing (Location, Range)
 import Parser exposing ((|.), (|=), Parser)
 import Regex exposing (Regex)
-import String exposing (startsWith)
+import String
 import Url exposing (Url)
 import Url.Parser exposing ((</>))
 

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -1,5 +1,6 @@
 module Docs.Utils.Link exposing
-    ( FileTarget(..)
+    ( ExternalPackageReference(..)
+    , FileTarget(..)
     , Link
     , SubTarget(..)
     , findLinks
@@ -11,6 +12,8 @@ import Elm.Syntax.Node exposing (Node(..))
 import Elm.Syntax.Range exposing (Location, Range)
 import Parser exposing ((|.), (|=), Parser)
 import Regex exposing (Regex)
+import Url
+import Url.Parser exposing ((</>))
 
 
 addOffset : Int -> Range -> Range
@@ -301,7 +304,21 @@ type ExternalPackageReference
 
 urlToExternalPackageReference : String -> Maybe ExternalPackageReference
 urlToExternalPackageReference url =
-    Debug.todo "parsing"
+    let
+        parser =
+            Url.Parser.s "packages"
+                </> Url.Parser.string
+                </> Url.Parser.string
+                |> Url.Parser.map
+                    (\author name ->
+                        ExternalPackageVersionSelectionReference
+                            { author = author
+                            , name = name
+                            }
+                    )
+    in
+    Url.fromString url
+        |> Maybe.andThen (Url.Parser.parse parser)
 
 
 ignoreDotSlash : Parser Bool

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -5,6 +5,7 @@ module Docs.Utils.Link exposing
     , SubTarget(..)
     , findLinks
     , parseExternalPackageLink
+    , subTargetVersion
     )
 
 import Elm.Project exposing (Project(..))
@@ -109,6 +110,19 @@ findLinks row moduleName string =
                         )
             )
         |> List.concat
+
+
+subTargetVersion : SubTarget -> Maybe String
+subTargetVersion subTarget =
+    case subTarget of
+        ReadmeSubTarget ver ->
+            Just ver
+
+        ModuleSubTarget ver _ ->
+            Just ver
+
+        VersionsSubTarget ->
+            Nothing
 
 
 linkParser : Int -> ModuleName -> Parser (Maybe (Node Link))

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -1,7 +1,7 @@
 module Docs.Utils.Link exposing
     ( FileTarget(..)
     , Link
-    , LinkStartsWith(..)
+    , StartsWith(..)
     , SubTarget(..)
     , findLinks
     , parseExternalPackageUrl
@@ -35,7 +35,7 @@ addLineNumber lineNumber { row, column } =
 
 type alias Link =
     { file : FileTarget
-    , linkStartsWith : LinkStartsWith
+    , startsWith : StartsWith
     , slug : Maybe String
     }
 
@@ -53,10 +53,10 @@ type SubTarget
     | ModuleSubTarget String ModuleName
 
 
-type LinkStartsWith
-    = LinkStartsWithDotSlash
-    | LinkStartsWithSlash
-    | OtherLinkStart
+type StartsWith
+    = StartsWithDotSlash
+    | StartsWithSlash
+    | StartsWithOther
 
 
 idParser : Char -> Parser String
@@ -219,22 +219,22 @@ pathParser endChar =
     Parser.oneOf
         [ Parser.succeed
             (\section ->
-                { file = ModuleTarget [], linkStartsWith = OtherLinkStart, slug = Just section }
+                { file = ModuleTarget [], startsWith = StartsWithOther, slug = Just section }
             )
             |. Parser.symbol "#"
             |= idParser endChar
         , Parser.succeed
             (\startsWithDotSlash { fileTarget, startsWithSlash } slug ->
                 { file = fileTarget
-                , linkStartsWith =
+                , startsWith =
                     if startsWithDotSlash then
-                        LinkStartsWithDotSlash
+                        StartsWithDotSlash
 
                     else if startsWithSlash then
-                        LinkStartsWithSlash
+                        StartsWithSlash
 
                     else
-                        OtherLinkStart
+                        StartsWithOther
                 , slug = slug
                 }
             )

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -4,7 +4,7 @@ module Docs.Utils.Link exposing
     , StartsWith(..)
     , SubTarget(..)
     , findLinks
-    , parseExternalPackageUrl
+    , parseExternalPackageLink
     )
 
 import Elm.Project exposing (Project(..))
@@ -274,7 +274,7 @@ parseModuleName =
                             }
 
                         Err _ ->
-                            case parseExternalPackageUrl linkTarget of
+                            case parseExternalPackageLink linkTarget of
                                 Just result ->
                                     result
 
@@ -285,8 +285,8 @@ parseModuleName =
             )
 
 
-parseExternalPackageUrl : String -> Maybe { fileTarget : FileTarget, startsWithSlash : Bool }
-parseExternalPackageUrl urlString =
+parseExternalPackageLink : String -> Maybe { fileTarget : FileTarget, startsWithSlash : Bool }
+parseExternalPackageLink urlString =
     let
         authorName =
             Url.Parser.s "packages"

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -3,7 +3,7 @@ module Docs.Utils.Link exposing
     , Link
     , SubTarget(..)
     , findLinks
-    , packageLinkParser
+    , urlToExternalPackageReference
     )
 
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -299,9 +299,9 @@ type ExternalPackageReference
         }
 
 
-packageLinkParser : Parser ExternalPackageReference
-packageLinkParser =
-    Debug.todo "parser"
+urlToExternalPackageReference : String -> Maybe ExternalPackageReference
+urlToExternalPackageReference url =
+    Debug.todo "parsing"
 
 
 ignoreDotSlash : Parser Bool

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -3,6 +3,7 @@ module Docs.Utils.Link exposing
     , Link
     , SubTarget(..)
     , findLinks
+    , packageLinkParser
     )
 
 import Elm.Syntax.ModuleName exposing (ModuleName)
@@ -278,6 +279,29 @@ linkRegex : Regex
 linkRegex =
     Regex.fromString "https://package\\.elm-lang\\.org/packages/([\\w-]+/[\\w-]+)/(latest|\\w+\\.\\w+\\.\\w+)(/(.*))?"
         |> Maybe.withDefault Regex.never
+
+
+type ExternalPackageReference
+    = ExternalPackageVersionSelectionReference
+        { author : String
+        , name : String
+        }
+    | ExternalPackageVersionReference
+        { author : String
+        , name : String
+        , version : String
+        }
+    | ExternalPackageSectionReference
+        { author : String
+        , name : String
+        , version : String
+        , section : String
+        }
+
+
+packageLinkParser : Parser ExternalPackageReference
+packageLinkParser =
+    Debug.todo "parser"
 
 
 ignoreDotSlash : Parser Bool

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -297,7 +297,7 @@ parseExternalPackageLink urlString =
             authorName
                 </> Url.Parser.string
 
-        authorNameVersionSection =
+        authorNameVersionModule =
             authorNameVersion
                 </> Url.Parser.string
                 </> Url.Parser.fragment identity
@@ -320,7 +320,7 @@ parseExternalPackageLink urlString =
                                 , subTarget = ReadmeSubTarget version
                                 }
                         )
-                , authorNameVersionSection
+                , authorNameVersionModule
                     |> Url.Parser.map
                         (\author name version module_ _ ->
                             PackagesTarget

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -303,7 +303,7 @@ type ExternalPackageReference
 
 
 urlToExternalPackageReference : String -> Maybe ExternalPackageReference
-urlToExternalPackageReference url =
+urlToExternalPackageReference urlString =
     let
         authorName =
             Url.Parser.s "packages"
@@ -358,9 +358,24 @@ urlToExternalPackageReference url =
                                 }
                         )
                 ]
+
+        urlMaybe =
+            case Url.fromString urlString of
+                Just u ->
+                    Just u
+
+                Nothing ->
+                    Url.fromString ("https://package.elm-lang.org" ++ urlString)
     in
-    Url.fromString url
-        |> Maybe.andThen (Url.Parser.parse parser)
+    urlMaybe
+        |> Maybe.andThen
+            (\url ->
+                if url.host == "package.elm-lang.org" then
+                    Url.Parser.parse parser url
+
+                else
+                    Nothing
+            )
 
 
 ignoreDotSlash : Parser Bool

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -128,14 +128,27 @@ subTargetVersion subTarget =
             Nothing
 
 
-formatPackageLink : { name : String, subTarget : SubTarget, slug : Maybe String } -> String
+formatPackageLink :
+    { name : String, subTarget : SubTarget, slug : Maybe String, absolutePath : Bool }
+    -> String
 formatPackageLink attrs =
     formatPackageLinkForVersion (subTargetVersion attrs.subTarget) attrs
 
 
-formatPackageLinkForVersion : Maybe String -> { name : String, subTarget : SubTarget, slug : Maybe String } -> String
-formatPackageLinkForVersion versionMaybe { name, subTarget, slug } =
-    "https://package.elm-lang.org/packages/"
+formatPackageLinkForVersion :
+    Maybe String
+    -> { name : String, subTarget : SubTarget, slug : Maybe String, absolutePath : Bool }
+    -> String
+formatPackageLinkForVersion versionMaybe { name, subTarget, slug, absolutePath } =
+    let
+        linkStart =
+            if absolutePath then
+                "/packages/"
+
+            else
+                "https://package.elm-lang.org/packages/"
+    in
+    linkStart
         ++ name
         ++ "/"
         ++ formatSubTargetForVersion versionMaybe subTarget

--- a/src/Docs/Utils/Link.elm
+++ b/src/Docs/Utils/Link.elm
@@ -4,6 +4,9 @@ module Docs.Utils.Link exposing
     , StartsWith(..)
     , SubTarget(..)
     , findLinks
+    , formatPackageLink
+    , formatPackageLinkForVersion
+    , formatSlug
     , parseExternalPackageLink
     , subTargetVersion
     )
@@ -123,6 +126,48 @@ subTargetVersion subTarget =
 
         VersionsSubTarget ->
             Nothing
+
+
+formatPackageLink : { name : String, subTarget : SubTarget, slug : Maybe String } -> String
+formatPackageLink attrs =
+    formatPackageLinkForVersion (subTargetVersion attrs.subTarget) attrs
+
+
+formatPackageLinkForVersion : Maybe String -> { name : String, subTarget : SubTarget, slug : Maybe String } -> String
+formatPackageLinkForVersion versionMaybe { name, subTarget, slug } =
+    "https://package.elm-lang.org/packages/"
+        ++ name
+        ++ "/"
+        ++ formatSubTargetForVersion versionMaybe subTarget
+        ++ formatSlug slug
+
+
+formatSubTargetForVersion : Maybe String -> SubTarget -> String
+formatSubTargetForVersion versionMaybe subTarget =
+    case versionMaybe of
+        Just version ->
+            case subTarget of
+                ModuleSubTarget _ moduleName ->
+                    version ++ "/" ++ String.join "-" moduleName ++ "/"
+
+                ReadmeSubTarget _ ->
+                    version ++ "/"
+
+                VersionsSubTarget ->
+                    ""
+
+        Nothing ->
+            ""
+
+
+formatSlug : Maybe String -> String
+formatSlug maybeSlug =
+    case maybeSlug of
+        Just slug ->
+            "#" ++ slug
+
+        Nothing ->
+            ""
 
 
 linkParser : Int -> ModuleName -> Parser (Maybe (Node Link))

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -985,6 +985,31 @@ a = 2
 """
                     |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
                     |> Review.Test.expectNoErrors
+        , test "should report links to packages using absolute-path URLs when the project is not a package" <|
+            \() ->
+                """module A exposing (..)
+{-|
+[link](/packages/elm/core/latest/Basics#Int)
+-}
+a = 2
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Link to package using absolute-path"
+                            , details =
+                                [ "Links to packages starting with \"/\" work great for docs viewed from the package site, but not for app docs."
+                                , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."
+                                ]
+                            , under = "/packages/elm/core/latest/Basics#Int"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+{-|
+[link](https://package.elm-lang.org/packages/elm/core/latest/Basics#Int)
+-}
+a = 2
+"""
+                        ]
         , test "should report links to an external resource without a protocol" <|
             \() ->
                 """module A exposing (..)

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -545,31 +545,22 @@ linksThroughPackageRegistryTest =
         [ test "should report links to unknown modules for the current version" <|
             \() ->
                 [ """module A exposing (..)
-{-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/Unknown)
+{-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/Unknown1)
+[link](/packages/author/package/1.0.0/Unknown2)
 -}
 a = 2
 """ ]
                     |> Review.Test.runOnModulesWithProjectData packageProjectWithoutFiles rule
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Link points to non-existing module Unknown"
+                            { message = "Link points to non-existing module Unknown1"
                             , details = [ "This is a dead link." ]
-                            , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown"
+                            , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown1"
                             }
-                        ]
-        , test "should report links to unknown modules for the current version (using absolute-path URLs)" <|
-            \() ->
-                [ """module A exposing (..)
-{-| [link](/packages/author/package/1.0.0/Unknown)
--}
-a = 2
-""" ]
-                    |> Review.Test.runOnModulesWithProjectData packageProjectWithoutFiles rule
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Link points to non-existing module Unknown"
+                        , Review.Test.error
+                            { message = "Link points to non-existing module Unknown2"
                             , details = [ "This is a dead link." ]
-                            , under = "/packages/author/package/1.0.0/Unknown"
+                            , under = "/packages/author/package/1.0.0/Unknown2"
                             }
                         ]
         , test "should not report links to known modules for the current version" <|
@@ -595,31 +586,22 @@ a = 2
         , test "should report links to unknown modules for latest" <|
             \() ->
                 """module A exposing (..)
-{-| [link](https://package.elm-lang.org/packages/author/package/latest/Unknown)
+{-| [link](https://package.elm-lang.org/packages/author/package/latest/Unknown1)
+[link](/packages/author/package/latest/Unknown2)
 -}
 a = 2
 """
                     |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Link points to non-existing module Unknown"
+                            { message = "Link points to non-existing module Unknown1"
                             , details = [ "This is a dead link." ]
-                            , under = "https://package.elm-lang.org/packages/author/package/latest/Unknown"
+                            , under = "https://package.elm-lang.org/packages/author/package/latest/Unknown1"
                             }
-                        ]
-        , test "should report links to unknown modules for latest (using absolute-path URLs)" <|
-            \() ->
-                """module A exposing (..)
-{-| [link](/packages/author/package/latest/Unknown)
--}
-a = 2
-"""
-                    |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Link points to non-existing module Unknown"
+                        , Review.Test.error
+                            { message = "Link points to non-existing module Unknown2"
                             , details = [ "This is a dead link." ]
-                            , under = "/packages/author/package/latest/Unknown"
+                            , under = "/packages/author/package/latest/Unknown2"
                             }
                         ]
         , test "should not report links for different version of the package" <|
@@ -635,7 +617,8 @@ a = 2
         , test "should report links to unknown section of README" <|
             \() ->
                 """module A exposing (..)
-{-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/#unknown)
+{-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/#unknown1)
+[link](/packages/author/package/1.0.0/#unknown2)
 -}
 a = 2
 """
@@ -646,24 +629,12 @@ a = 2
                         [ Review.Test.error
                             { message = "Link points to a non-existing section or element"
                             , details = [ "This is a dead link." ]
-                            , under = "https://package.elm-lang.org/packages/author/package/1.0.0/#unknown"
+                            , under = "https://package.elm-lang.org/packages/author/package/1.0.0/#unknown1"
                             }
-                        ]
-        , test "should report links to unknown section of README (using absolute-path URLs)" <|
-            \() ->
-                """module A exposing (..)
-{-| [link](/packages/author/package/1.0.0/#unknown)
--}
-a = 2
-"""
-                    |> Review.Test.runWithProjectData
-                        (Project.addReadme { path = "README.md", content = "# A" } packageProjectWithoutFiles)
-                        rule
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
+                        , Review.Test.error
                             { message = "Link points to a non-existing section or element"
                             , details = [ "This is a dead link." ]
-                            , under = "/packages/author/package/1.0.0/#unknown"
+                            , under = "/packages/author/package/1.0.0/#unknown2"
                             }
                         ]
         , test "should not report links to known sections of README" <|
@@ -1149,12 +1120,13 @@ a = 2
                             , under = "/packages/author/package/1.0.0/Unknown"
                             }
                         ]
-        , test "should report absolute or absolute-path links to unknown modules in links with alt text without a slug" <|
+        , test "should report absolute and absolute-path links to unknown modules in links with alt text without a slug" <|
             \() ->
                 """module A exposing (a, b)
 b = 1
 
 {-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/Unknown#section "alt-text")
+[link](/packages/author/package/1.0.0/Unknown2#section "alt-text")
 -}
 a = 2
 """
@@ -1164,6 +1136,11 @@ a = 2
                             { message = "Link points to non-existing module Unknown"
                             , details = [ "This is a dead link." ]
                             , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown#section"
+                            }
+                        , Review.Test.error
+                            { message = "Link points to non-existing module Unknown2"
+                            , details = [ "This is a dead link." ]
+                            , under = "/packages/author/package/1.0.0/Unknown2#section"
                             }
                         ]
         , test "should report absolute or absolute-path links to unknown modules in links with alt text without a slug (using absolute-path URLs)" <|

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -1216,17 +1216,3 @@ elmJson =
     },
     "test-dependencies": {}
 }"""
-
-
-addReadme : String -> Project -> Project
-addReadme content =
-    Project.addReadme { path = "README.md", content = content }
-
-
-readmeWithLink : String -> String
-readmeWithLink link =
-    """
-# My project
-
-  - [my project's thing](""" ++ link ++ """)
-"""

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -37,7 +37,7 @@ messageAbsolutePath =
 
 detailsAbsolutePath : List String
 detailsAbsolutePath =
-    [ "Links starting with \"/\" don't work when looking at the docs from GitHub or the likes."
+    [ "Links starting with \"/\" don't work when looking at your README from GitHub or the likes."
     , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."
     ]
 

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -975,7 +975,7 @@ a = 2
 """
                     |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
                     |> Review.Test.expectNoErrors
-        , test "should not report links to packages using absolute-path URLs" <|
+        , test "should not report links to packages using absolute paths" <|
             \() ->
                 """module A exposing (..)
 {-|
@@ -985,7 +985,7 @@ a = 2
 """
                     |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
                     |> Review.Test.expectNoErrors
-        , test "should report links to packages using absolute-path URLs when the project is not a package" <|
+        , test "should report links to packages using absolute paths when the project is not a package" <|
             \() ->
                 """module A exposing (..)
 {-|
@@ -996,7 +996,7 @@ a = 2
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Link to package using absolute-path"
+                            { message = "Link to package using absolute path"
                             , details =
                                 [ "Links to packages starting with \"/\" work great for docs viewed from the package site, but not for app docs."
                                 , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -1187,7 +1187,7 @@ absolutePathPackageLinksInReadme =
                             , details = detailsAbsolutePath
                             , under = "/packages/author/package/1.2.3/Module-Name"
                             }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name")
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
         , test "should report links to a package's README using absolute paths from the README" <|
             \() ->

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -1086,38 +1086,27 @@ a = 2
                             , under = "Unknown"
                             }
                         ]
-        , test "should report absolute links to unknown modules in links with alt text with a slug" <|
+        , test "should report absolute and absolute-path links to unknown modules in links with alt text with a slug" <|
             \() ->
                 """module A exposing (a, b)
 b = 1
 
-{-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/Unknown "alt-text")
+{-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/Unknown1 "alt-text")
+[link](/packages/author/package/1.0.0/Unknown2 "alt-text")
 -}
 a = 2
 """
                     |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Link points to non-existing module Unknown"
+                            { message = "Link points to non-existing module Unknown1"
                             , details = [ "This is a dead link." ]
-                            , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown"
+                            , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown1"
                             }
-                        ]
-        , test "should report absolute links to unknown modules in links with alt text with a slug (using absolute-path URLs)" <|
-            \() ->
-                """module A exposing (a, b)
-b = 1
-
-{-| [link](/packages/author/package/1.0.0/Unknown "alt-text")
--}
-a = 2
-"""
-                    |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Link points to non-existing module Unknown"
+                        , Review.Test.error
+                            { message = "Link points to non-existing module Unknown2"
                             , details = [ "This is a dead link." ]
-                            , under = "/packages/author/package/1.0.0/Unknown"
+                            , under = "/packages/author/package/1.0.0/Unknown2"
                             }
                         ]
         , test "should report absolute and absolute-path links to unknown modules in links with alt text without a slug" <|
@@ -1141,23 +1130,6 @@ a = 2
                             { message = "Link points to non-existing module Unknown2"
                             , details = [ "This is a dead link." ]
                             , under = "/packages/author/package/1.0.0/Unknown2#section"
-                            }
-                        ]
-        , test "should report absolute or absolute-path links to unknown modules in links with alt text without a slug (using absolute-path URLs)" <|
-            \() ->
-                """module A exposing (a, b)
-b = 1
-
-{-| [link](/packages/author/package/1.0.0/Unknown#section "alt-text")
--}
-a = 2
-"""
-                    |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Link points to non-existing module Unknown"
-                            , details = [ "This is a dead link." ]
-                            , under = "/packages/author/package/1.0.0/Unknown#section"
                             }
                         ]
         ]

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -952,6 +952,16 @@ a = 2
 """
                     |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
                     |> Review.Test.expectNoErrors
+        , test "should not report links to packages using absolute-path URLs" <|
+            \() ->
+                """module A exposing (..)
+{-|
+[link](/packages/elm/core/latest/Basics#Int)
+-}
+a = 2
+"""
+                    |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
+                    |> Review.Test.expectNoErrors
         , test "should report links to an external resource without a protocol" <|
             \() ->
                 """module A exposing (..)

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -4,7 +4,7 @@ import Docs.ReviewLinksAndSections exposing (rule)
 import Elm.Project
 import Json.Decode
 import Review.Project as Project exposing (Project)
-import Review.Test exposing (ReviewResult)
+import Review.Test
 import Test exposing (Test, describe, test)
 
 
@@ -26,20 +26,7 @@ all =
         , unnecessaryLinksTests
         , externalResourcesTests
         , linksWithAltTextTests
-        , absolutePathPackageLinksInReadme
         ]
-
-
-messageAbsolutePath : String
-messageAbsolutePath =
-    "README uses an absolute-path link to a package"
-
-
-detailsAbsolutePath : List String
-detailsAbsolutePath =
-    [ "Links starting with \"/\" don't work when looking at your README from GitHub or the likes."
-    , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."
-    ]
 
 
 localLinkTests : Test
@@ -1186,58 +1173,6 @@ a = 2
                             }
                         ]
         ]
-
-
-absolutePathPackageLinksInReadme : Test
-absolutePathPackageLinksInReadme =
-    describe "Absolute-path package links in README"
-        [ test "should report links to a package's module using absolute paths from the README" <|
-            \() ->
-                Project.new
-                    |> addReadme (readmeWithLink "/packages/author/package/1.2.3/Module-Name")
-                    |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
-                            , under = "/packages/author/package/1.2.3/Module-Name"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
-                        ]
-        , test "should report links to a package's README using absolute paths from the README" <|
-            \() ->
-                Project.new
-                    |> addReadme (readmeWithLink "/packages/author/package/1.2.3/")
-                    |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
-                            , under = "/packages/author/package/1.2.3/"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/")
-                        ]
-        , test "should report links to a package's versions page using absolute paths from the README" <|
-            \() ->
-                Project.new
-                    |> addReadme (readmeWithLink "/packages/author/package/")
-                    |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
-                            , under = "/packages/author/package/"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/")
-                        ]
-        ]
-
-
-testRule : Project -> ReviewResult
-testRule project =
-    """module SomeModule exposing (a)
-a = 1"""
-        |> Review.Test.runWithProjectData project rule
 
 
 packageProject : Project

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -1018,7 +1018,7 @@ a = 2
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 {-|
-[link](https://package.elm-lang.org/packages/elm/core/latest/Basics#Int)
+[link](https://package.elm-lang.org/packages/elm/core/latest/Basics/#Int)
 -}
 a = 2
 """

--- a/tests/Docs/ReviewLinksAndSectionsTest.elm
+++ b/tests/Docs/ReviewLinksAndSectionsTest.elm
@@ -557,10 +557,26 @@ a = 2
                             , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown"
                             }
                         ]
+        , test "should report links to unknown modules for the current version (using absolute-path URLs)" <|
+            \() ->
+                [ """module A exposing (..)
+{-| [link](/packages/author/package/1.0.0/Unknown)
+-}
+a = 2
+""" ]
+                    |> Review.Test.runOnModulesWithProjectData packageProjectWithoutFiles rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Link points to non-existing module Unknown"
+                            , details = [ "This is a dead link." ]
+                            , under = "/packages/author/package/1.0.0/Unknown"
+                            }
+                        ]
         , test "should not report links to known modules for the current version" <|
             \() ->
                 [ """module A exposing (..)
 {-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/A)
+[link](/packages/author/package/1.0.0/A)
 -}
 a = 2
 """ ]
@@ -570,6 +586,7 @@ a = 2
             \() ->
                 [ """module A exposing (..)
 {-| [link](https://package.elm-lang.org/packages/author/package/1.0.0/A/)
+[link](/packages/author/package/1.0.0/A/)
 -}
 a = 2
 """ ]
@@ -590,10 +607,26 @@ a = 2
                             , under = "https://package.elm-lang.org/packages/author/package/latest/Unknown"
                             }
                         ]
+        , test "should report links to unknown modules for latest (using absolute-path URLs)" <|
+            \() ->
+                """module A exposing (..)
+{-| [link](/packages/author/package/latest/Unknown)
+-}
+a = 2
+"""
+                    |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Link points to non-existing module Unknown"
+                            , details = [ "This is a dead link." ]
+                            , under = "/packages/author/package/latest/Unknown"
+                            }
+                        ]
         , test "should not report links for different version of the package" <|
             \() ->
                 """module A exposing (..)
 {-| [link](https://package.elm-lang.org/packages/author/package/2.3.4/Unknown)
+[link](/packages/author/package/2.3.4/Unknown)
 -}
 a = 2
 """
@@ -616,10 +649,28 @@ a = 2
                             , under = "https://package.elm-lang.org/packages/author/package/1.0.0/#unknown"
                             }
                         ]
+        , test "should report links to unknown section of README (using absolute-path URLs)" <|
+            \() ->
+                """module A exposing (..)
+{-| [link](/packages/author/package/1.0.0/#unknown)
+-}
+a = 2
+"""
+                    |> Review.Test.runWithProjectData
+                        (Project.addReadme { path = "README.md", content = "# A" } packageProjectWithoutFiles)
+                        rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Link points to a non-existing section or element"
+                            , details = [ "This is a dead link." ]
+                            , under = "/packages/author/package/1.0.0/#unknown"
+                            }
+                        ]
         , test "should not report links to known sections of README" <|
             \() ->
                 """module A exposing (..)
 {-| [link](https://package.elm-lang.org/packages/author/package/2.3.4/#a)
+[link](/packages/author/package/2.3.4/#a)
 -}
 a = 2
 """
@@ -631,6 +682,7 @@ a = 2
             \() ->
                 """module A exposing (..)
 {-| [link](https://package.elm-lang.org/packages/other-author/package/latest/Unknown/)
+[link](/packages/other-author/package/latest/Unknown/)
 -}
 a = 2
 """
@@ -1080,7 +1132,24 @@ a = 2
                             , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown"
                             }
                         ]
-        , test "should report absolute links to unknown modules in links with alt text without a slug" <|
+        , test "should report absolute links to unknown modules in links with alt text with a slug (using absolute-path URLs)" <|
+            \() ->
+                """module A exposing (a, b)
+b = 1
+
+{-| [link](/packages/author/package/1.0.0/Unknown "alt-text")
+-}
+a = 2
+"""
+                    |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Link points to non-existing module Unknown"
+                            , details = [ "This is a dead link." ]
+                            , under = "/packages/author/package/1.0.0/Unknown"
+                            }
+                        ]
+        , test "should report absolute or absolute-path links to unknown modules in links with alt text without a slug" <|
             \() ->
                 """module A exposing (a, b)
 b = 1
@@ -1095,6 +1164,23 @@ a = 2
                             { message = "Link points to non-existing module Unknown"
                             , details = [ "This is a dead link." ]
                             , under = "https://package.elm-lang.org/packages/author/package/1.0.0/Unknown#section"
+                            }
+                        ]
+        , test "should report absolute or absolute-path links to unknown modules in links with alt text without a slug (using absolute-path URLs)" <|
+            \() ->
+                """module A exposing (a, b)
+b = 1
+
+{-| [link](/packages/author/package/1.0.0/Unknown#section "alt-text")
+-}
+a = 2
+"""
+                    |> Review.Test.runWithProjectData packageProjectWithoutFiles rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Link points to non-existing module Unknown"
+                            , details = [ "This is a dead link." ]
+                            , under = "/packages/author/package/1.0.0/Unknown#section"
                             }
                         ]
         ]

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -60,6 +60,18 @@ details =
     [ "I suggest to run elm-review --fix to get the correct link." ]
 
 
+messageAbsolutePath : String
+messageAbsolutePath =
+    "README link uses an absolute-path"
+
+
+detailsAbsolutePath : List String
+detailsAbsolutePath =
+    [ "Links starting with \"/\" don't work when looking at the docs from GitHub or the likes."
+    , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."
+    ]
+
+
 readmeWithLink : String -> String
 readmeWithLink link =
     """
@@ -96,7 +108,7 @@ all =
                     |> addReadme "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name"
                     |> testRule
                     |> Review.Test.expectNoErrors
-        , test "should report an error if a link points to a different version" <|
+        , test "should report an error if a link points to a different version of own package" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -110,7 +122,21 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
-        , test "should report an error if a link points to a different version (using an absolute-path URL)" <|
+        , test "should report an absolute-path error if such a link points to current version of own package" <|
+            \() ->
+                Project.new
+                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
+                    |> addReadme "/packages/author/package/1.2.3/Module-Name"
+                    |> testRule
+                    |> Review.Test.expectErrorsForReadme
+                        [ Review.Test.error
+                            { message = messageAbsolutePath
+                            , details = detailsAbsolutePath
+                            , under = "/packages/author/package/1.2.3/Module-Name"
+                            }
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
+                        ]
+        , test "should report an absolute-path error if such a link points to a different version of own package" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -118,13 +144,13 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = message
-                            , details = details
+                            { message = messageAbsolutePath
+                            , details = detailsAbsolutePath
                             , under = "/packages/author/package/1.2.4/Module-Name"
                             }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.4/Module-Name/")
                         ]
-        , test "should report an error if a link points to a package module using an absolute-path URL" <|
+        , test "should report an error if a link points to any package's module using an absolute-path URL" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -132,16 +158,13 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = "Readme link uses an absolute-path"
-                            , details =
-                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
-                                , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
-                                ]
+                            { message = messageAbsolutePath
+                            , details = detailsAbsolutePath
                             , under = "/packages/another-author/another-package/2.3.4/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/2.3.4/Module-Name/")
                         ]
-        , test "should report an error if a link points to a package README using an absolute-path URL" <|
+        , test "should report an error if a link points to any package's README using an absolute-path URL" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -149,16 +172,13 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = "Readme link uses an absolute-path"
-                            , details =
-                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
-                                , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
-                                ]
+                            { message = messageAbsolutePath
+                            , details = detailsAbsolutePath
                             , under = "/packages/another-author/another-package/2.3.4"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/2.3.4/")
                         ]
-        , test "should report an error if a link points to a package versions page using an absolute-path URL" <|
+        , test "should report an error if a link points to any package's versions page using an absolute-path URL" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -166,11 +186,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = "Readme link uses an absolute-path"
-                            , details =
-                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
-                                , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
-                                ]
+                            { message = messageAbsolutePath
+                            , details = detailsAbsolutePath
                             , under = "/packages/another-author/another-package/"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/")

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -50,13 +50,13 @@ packageElmJson name =
 }"""
 
 
-message : String
-message =
+messageVersion : String
+messageVersion =
     "Link does not point to the current version of the package"
 
 
-details : List String
-details =
+detailsVersion : List String
+detailsVersion =
     [ "I suggest to run elm-review --fix to get the correct link." ]
 
 
@@ -116,8 +116,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = message
-                            , details = details
+                            { message = messageVersion
+                            , details = detailsVersion
                             , under = "https://package.elm-lang.org/packages/author/package/1.2.4/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
@@ -202,16 +202,16 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = message
-                            , details = details
+                            { message = messageVersion
+                            , details = detailsVersion
                             , under = "https://package.elm-lang.org/packages/author/package/1.2.4/A"
                             }
                             |> Review.Test.whenFixed """
 [link1](https://package.elm-lang.org/packages/author/package/1.2.3/A/) [link2](https://package.elm-lang.org/packages/author/package/1.2.4/B)
 """
                         , Review.Test.error
-                            { message = message
-                            , details = details
+                            { message = messageVersion
+                            , details = detailsVersion
                             , under = "https://package.elm-lang.org/packages/author/package/1.2.4/B"
                             }
                             |> Review.Test.whenFixed """
@@ -226,8 +226,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = message
-                            , details = details
+                            { message = messageVersion
+                            , details = detailsVersion
                             , under = "https://package.elm-lang.org/packages/author/package/latest/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
@@ -240,8 +240,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = message
-                            , details = details
+                            { message = messageVersion
+                            , details = detailsVersion
                             , under = "https://package.elm-lang.org/packages/au-tho5r/pack-age1/latest/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/au-tho5r/pack-age1/1.2.3/Module-Name/")
@@ -330,8 +330,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = "Link does not point to the current version of the package"
-                            , details = details
+                            { message = messageVersion
+                            , details = detailsVersion
                             , under = "https://package.elm-lang.org/packages/au-tho5r/pack-age1/latest/"
                             }
                             |> Review.Test.whenFixed """

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -110,6 +110,23 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
+        , test "should report an error if a link points to the current project using an absolute-path URL" <|
+            \() ->
+                Project.new
+                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
+                    |> addReadme "/packages/author/package/1.2.3/Module-Name"
+                    |> testRule
+                    |> Review.Test.expectErrorsForReadme
+                        [ Review.Test.error
+                            { message = "Readme link uses an absolute-path"
+                            , details =
+                                [ "Absolute-path links (starting with '/') don't work when looking at the docs from GitHub or the likes."
+                                , "I suggest to run elm-review --fix to change the link to an absolute link (from 'https://')."
+                                ]
+                            , under = "/packages/author/package/1.2.3/Module-Name"
+                            }
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
+                        ]
         , test "should report errors for multiple links on the same line" <|
             \() ->
                 Project.new

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -239,6 +239,23 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "#section")
                         ]
+        , test "should report an error if the link points to the README using an absolute-path" <|
+            \() ->
+                Project.new
+                    |> Project.addElmJson (createElmJson <| packageElmJson "au-tho5r/pack-age1")
+                    |> addReadme "/packages/au-tho5r/pack-age1/1.2.3/#section"
+                    |> testRule
+                    |> Review.Test.expectErrorsForReadme
+                        [ Review.Test.error
+                            { message = "Found an absolute-path link from and to README"
+                            , details =
+                                [ "Absolute-path links (starting with '/') don't work when looking at the docs from GitHub or the likes."
+                                , "I suggest to run elm-review --fix to change the link to a relative link."
+                                ]
+                            , under = "/packages/au-tho5r/pack-age1/1.2.3/#section"
+                            }
+                            |> Review.Test.whenFixed (readmeWithLink "#section")
+                        ]
         , test "should report an error but not provide a fix if the link is exactly ./" <|
             \() ->
                 Project.new

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -60,18 +60,6 @@ detailsVersion =
     [ "I suggest to run elm-review --fix to get the correct link." ]
 
 
-messageAbsolutePath : String
-messageAbsolutePath =
-    "README link uses an absolute-path"
-
-
-detailsAbsolutePath : List String
-detailsAbsolutePath =
-    [ "Links starting with \"/\" don't work when looking at the docs from GitHub or the likes."
-    , "I suggest to run elm-review --fix to change the link to an absolute link (\"https://...\")."
-    ]
-
-
 readmeWithLink : String -> String
 readmeWithLink link =
     """
@@ -122,21 +110,14 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
-        , test "should report an absolute-path error if such a link points to current version of own package" <|
+        , test "should not report an error if there are absolute-path links pointing to current version of own package" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
                     |> addReadme "/packages/author/package/1.2.3/Module-Name"
                     |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
-                            , under = "/packages/author/package/1.2.3/Module-Name"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
-                        ]
-        , test "should report an absolute-path error if such a link points to a different version of own package" <|
+                    |> Review.Test.expectNoErrors
+        , test "should report an error if an absolute-path link points to a different version of own package" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -144,54 +125,33 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
+                            { message = messageVersion
+                            , details = detailsVersion
                             , under = "/packages/author/package/1.2.4/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.4/Module-Name/")
                         ]
-        , test "should report an error if a link points to any package's module using an absolute-path URL" <|
+        , test "should not report an error if a link points to any package's module using an absolute-path URL" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
                     |> addReadme "/packages/another-author/another-package/2.3.4/Module-Name"
                     |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
-                            , under = "/packages/another-author/another-package/2.3.4/Module-Name"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/2.3.4/Module-Name/")
-                        ]
-        , test "should report an error if a link points to any package's README using an absolute-path URL" <|
+                    |> Review.Test.expectNoErrors
+        , test "should not report an error if a link points to any package's README using an absolute-path URL" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
                     |> addReadme "/packages/another-author/another-package/2.3.4"
                     |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
-                            , under = "/packages/another-author/another-package/2.3.4"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/2.3.4/")
-                        ]
-        , test "should report an error if a link points to any package's versions page using an absolute-path URL" <|
+                    |> Review.Test.expectNoErrors
+        , test "should not report an error if a link points to any package's versions page using an absolute-path URL" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
                     |> addReadme "/packages/another-author/another-package/"
                     |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = messageAbsolutePath
-                            , details = detailsAbsolutePath
-                            , under = "/packages/another-author/another-package/"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/")
-                        ]
+                    |> Review.Test.expectNoErrors
         , test "should report errors for multiple links on the same line" <|
             \() ->
                 Project.new

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -50,13 +50,13 @@ packageElmJson name =
 }"""
 
 
-messageVersion : String
-messageVersion =
+message : String
+message =
     "Link does not point to the current version of the package"
 
 
-detailsVersion : List String
-detailsVersion =
+details : List String
+details =
     [ "I suggest to run elm-review --fix to get the correct link." ]
 
 
@@ -104,8 +104,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = messageVersion
-                            , details = detailsVersion
+                            { message = message
+                            , details = details
                             , under = "https://package.elm-lang.org/packages/author/package/1.2.4/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
@@ -125,8 +125,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = messageVersion
-                            , details = detailsVersion
+                            { message = message
+                            , details = details
                             , under = "/packages/author/package/1.2.4/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.4/Module-Name/")
@@ -162,16 +162,16 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = messageVersion
-                            , details = detailsVersion
+                            { message = message
+                            , details = details
                             , under = "https://package.elm-lang.org/packages/author/package/1.2.4/A"
                             }
                             |> Review.Test.whenFixed """
 [link1](https://package.elm-lang.org/packages/author/package/1.2.3/A/) [link2](https://package.elm-lang.org/packages/author/package/1.2.4/B)
 """
                         , Review.Test.error
-                            { message = messageVersion
-                            , details = detailsVersion
+                            { message = message
+                            , details = details
                             , under = "https://package.elm-lang.org/packages/author/package/1.2.4/B"
                             }
                             |> Review.Test.whenFixed """
@@ -186,8 +186,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = messageVersion
-                            , details = detailsVersion
+                            { message = message
+                            , details = details
                             , under = "https://package.elm-lang.org/packages/author/package/latest/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
@@ -200,8 +200,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = messageVersion
-                            , details = detailsVersion
+                            { message = message
+                            , details = details
                             , under = "https://package.elm-lang.org/packages/au-tho5r/pack-age1/latest/Module-Name"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/au-tho5r/pack-age1/1.2.3/Module-Name/")
@@ -290,8 +290,8 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = messageVersion
-                            , details = detailsVersion
+                            { message = message
+                            , details = details
                             , under = "https://package.elm-lang.org/packages/au-tho5r/pack-age1/latest/"
                             }
                             |> Review.Test.whenFixed """

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -120,8 +120,8 @@ all =
                         [ Review.Test.error
                             { message = "Readme link uses an absolute-path"
                             , details =
-                                [ "Absolute-path links (starting with '/') don't work when looking at the docs from GitHub or the likes."
-                                , "I suggest to run elm-review --fix to change the link to an absolute link (from 'https://')."
+                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
+                                , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
                                 ]
                             , under = "/packages/author/package/1.2.3/Module-Name"
                             }
@@ -249,7 +249,7 @@ all =
                         [ Review.Test.error
                             { message = "Found an absolute-path link from and to README"
                             , details =
-                                [ "Absolute-path links (starting with '/') don't work when looking at the docs from GitHub or the likes."
+                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
                                 , "I suggest to run elm-review --fix to change the link to a relative link."
                                 ]
                             , under = "/packages/au-tho5r/pack-age1/1.2.3/#section"

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -124,20 +124,6 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
-        , test "should report an error if there are absolute-path links pointing to current version" <|
-            \() ->
-                Project.new
-                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
-                    |> addReadme "/packages/author/package/1.2.3/Module-Name"
-                    |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = message
-                            , details = details
-                            , under = "/packages/author/package/1.2.3/Module-Name"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
-                        ]
         , test "should report errors for multiple links on the same line" <|
             \() ->
                 Project.new
@@ -276,7 +262,7 @@ all =
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
-                            { message = message
+                            { message = "Link does not point to the current version of the package"
                             , details = details
                             , under = "https://package.elm-lang.org/packages/au-tho5r/pack-age1/latest/"
                             }

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -96,7 +96,7 @@ all =
                     |> addReadme "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name"
                     |> testRule
                     |> Review.Test.expectNoErrors
-        , test "should report an error if a link points to a different version of own package" <|
+        , test "should report an error if a link points to a different version" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -110,7 +110,7 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
-        , test "should report an error if a link points to a different version of own package (using HTTP)" <|
+        , test "should report an error if a link points to a different version (using HTTP)" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
@@ -124,48 +124,20 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
-        , test "should not report an error if there are absolute-path links pointing to current version of own package" <|
+        , test "should report an error if there are absolute-path links pointing to current version" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
                     |> addReadme "/packages/author/package/1.2.3/Module-Name"
                     |> testRule
-                    |> Review.Test.expectNoErrors
-        , test "should report an error if an absolute-path link points to a different version of own package" <|
-            \() ->
-                Project.new
-                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
-                    |> addReadme "/packages/author/package/1.2.4/Module-Name"
-                    |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
                             { message = message
                             , details = details
-                            , under = "/packages/author/package/1.2.4/Module-Name"
+                            , under = "/packages/author/package/1.2.3/Module-Name"
                             }
-                            |> Review.Test.whenFixed (readmeWithLink "/packages/author/package/1.2.3/Module-Name/")
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
-        , test "should not report an error if a link points to any package's module using an absolute-path URL" <|
-            \() ->
-                Project.new
-                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
-                    |> addReadme "/packages/another-author/another-package/2.3.4/Module-Name"
-                    |> testRule
-                    |> Review.Test.expectNoErrors
-        , test "should not report an error if a link points to any package's README using an absolute-path URL" <|
-            \() ->
-                Project.new
-                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
-                    |> addReadme "/packages/another-author/another-package/2.3.4"
-                    |> testRule
-                    |> Review.Test.expectNoErrors
-        , test "should not report an error if a link points to any package's versions page using an absolute-path URL" <|
-            \() ->
-                Project.new
-                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
-                    |> addReadme "/packages/another-author/another-package/"
-                    |> testRule
-                    |> Review.Test.expectNoErrors
         , test "should report errors for multiple links on the same line" <|
             \() ->
                 Project.new

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -129,7 +129,7 @@ all =
                             , details = details
                             , under = "/packages/author/package/1.2.4/Module-Name"
                             }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.4/Module-Name/")
+                            |> Review.Test.whenFixed (readmeWithLink "/packages/author/package/1.2.3/Module-Name/")
                         ]
         , test "should not report an error if a link points to any package's module using an absolute-path URL" <|
             \() ->

--- a/tests/Docs/UpToDateReadmeLinksTest.elm
+++ b/tests/Docs/UpToDateReadmeLinksTest.elm
@@ -110,11 +110,25 @@ all =
                             }
                             |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
                         ]
-        , test "should report an error if a link points to the current project using an absolute-path URL" <|
+        , test "should report an error if a link points to a different version (using an absolute-path URL)" <|
             \() ->
                 Project.new
                     |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
-                    |> addReadme "/packages/author/package/1.2.3/Module-Name"
+                    |> addReadme "/packages/author/package/1.2.4/Module-Name"
+                    |> testRule
+                    |> Review.Test.expectErrorsForReadme
+                        [ Review.Test.error
+                            { message = message
+                            , details = details
+                            , under = "/packages/author/package/1.2.4/Module-Name"
+                            }
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
+                        ]
+        , test "should report an error if a link points to a package module using an absolute-path URL" <|
+            \() ->
+                Project.new
+                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
+                    |> addReadme "/packages/another-author/another-package/2.3.4/Module-Name"
                     |> testRule
                     |> Review.Test.expectErrorsForReadme
                         [ Review.Test.error
@@ -123,9 +137,43 @@ all =
                                 [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
                                 , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
                                 ]
-                            , under = "/packages/author/package/1.2.3/Module-Name"
+                            , under = "/packages/another-author/another-package/2.3.4/Module-Name"
                             }
-                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/author/package/1.2.3/Module-Name/")
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/2.3.4/Module-Name/")
+                        ]
+        , test "should report an error if a link points to a package README using an absolute-path URL" <|
+            \() ->
+                Project.new
+                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
+                    |> addReadme "/packages/another-author/another-package/2.3.4"
+                    |> testRule
+                    |> Review.Test.expectErrorsForReadme
+                        [ Review.Test.error
+                            { message = "Readme link uses an absolute-path"
+                            , details =
+                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
+                                , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
+                                ]
+                            , under = "/packages/another-author/another-package/2.3.4"
+                            }
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/2.3.4/")
+                        ]
+        , test "should report an error if a link points to a package versions page using an absolute-path URL" <|
+            \() ->
+                Project.new
+                    |> Project.addElmJson (createElmJson <| packageElmJson "author/package")
+                    |> addReadme "/packages/another-author/another-package/"
+                    |> testRule
+                    |> Review.Test.expectErrorsForReadme
+                        [ Review.Test.error
+                            { message = "Readme link uses an absolute-path"
+                            , details =
+                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
+                                , "I suggest to run elm-review --fix to change the link to an absolute link (from \"https://\")."
+                                ]
+                            , under = "/packages/another-author/another-package/"
+                            }
+                            |> Review.Test.whenFixed (readmeWithLink "https://package.elm-lang.org/packages/another-author/another-package/")
                         ]
         , test "should report errors for multiple links on the same line" <|
             \() ->
@@ -236,23 +284,6 @@ all =
                                 , "I suggest to remove the leading \"./\"."
                                 ]
                             , under = "./#section"
-                            }
-                            |> Review.Test.whenFixed (readmeWithLink "#section")
-                        ]
-        , test "should report an error if the link points to the README using an absolute-path" <|
-            \() ->
-                Project.new
-                    |> Project.addElmJson (createElmJson <| packageElmJson "au-tho5r/pack-age1")
-                    |> addReadme "/packages/au-tho5r/pack-age1/1.2.3/#section"
-                    |> testRule
-                    |> Review.Test.expectErrorsForReadme
-                        [ Review.Test.error
-                            { message = "Found an absolute-path link from and to README"
-                            , details =
-                                [ "Absolute-path links (starting with \"/\") don't work when looking at the docs from GitHub or the likes."
-                                , "I suggest to run elm-review --fix to change the link to a relative link."
-                                ]
-                            , under = "/packages/au-tho5r/pack-age1/1.2.3/#section"
                             }
                             |> Review.Test.whenFixed (readmeWithLink "#section")
                         ]

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -1,6 +1,6 @@
 module Docs.Utils.LinkTest exposing (parseExternalPackageUrlTest)
 
-import Docs.Utils.Link exposing (FileTarget(..), LinkStartsWith(..), SubTarget(..), parseExternalPackageUrl)
+import Docs.Utils.Link exposing (FileTarget(..), SubTarget(..), parseExternalPackageUrl)
 import Expect
 import Test exposing (Test, describe, test)
 
@@ -72,12 +72,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = VersionsSubTarget
-                                                }
-                                            , OtherLinkStart
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = VersionsSubTarget
+                                                    }
+                                            , startsWithSlash = False
+                                            }
                                         )
                     )
             )
@@ -90,12 +91,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = VersionsSubTarget
-                                                }
-                                            , LinkStartsWithSlash
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = VersionsSubTarget
+                                                    }
+                                            , startsWithSlash = True
+                                            }
                                         )
                     )
             )
@@ -108,12 +110,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = ReadmeSubTarget "1.1.1"
-                                                }
-                                            , OtherLinkStart
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = ReadmeSubTarget "1.1.1"
+                                                    }
+                                            , startsWithSlash = False
+                                            }
                                         )
                     )
             )
@@ -126,12 +129,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = ReadmeSubTarget "1.1.1"
-                                                }
-                                            , LinkStartsWithSlash
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = ReadmeSubTarget "1.1.1"
+                                                    }
+                                            , startsWithSlash = True
+                                            }
                                         )
                     )
             )
@@ -144,12 +148,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
-                                                }
-                                            , OtherLinkStart
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
+                                                    }
+                                            , startsWithSlash = False
+                                            }
                                         )
                     )
             )
@@ -162,12 +167,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
-                                                }
-                                            , LinkStartsWithSlash
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
+                                                    }
+                                            , startsWithSlash = True
+                                            }
                                         )
                     )
             )
@@ -180,12 +186,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
-                                                }
-                                            , OtherLinkStart
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
+                                                    }
+                                            , startsWithSlash = False
+                                            }
                                         )
                     )
             )
@@ -198,12 +205,13 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            ( PackagesTarget
-                                                { name = "elm/regex"
-                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
-                                                }
-                                            , LinkStartsWithSlash
-                                            )
+                                            { fileTarget =
+                                                PackagesTarget
+                                                    { name = "elm/regex"
+                                                    , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
+                                                    }
+                                            , startsWithSlash = True
+                                            }
                                         )
                     )
             )

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -139,7 +139,7 @@ parseExternalPackageLinkTest =
                                         )
                     )
             )
-        , describe "URLs with author, name, version and section"
+        , describe "URLs with author, name, version and module"
             (urlsWithAuthorNameVersionAndModule
                 |> List.map
                     (\url ->
@@ -158,7 +158,7 @@ parseExternalPackageLinkTest =
                                         )
                     )
             )
-        , describe "Absolute-path URLs with author, name, version and section"
+        , describe "Absolute-path URLs with author, name, version and module"
             (absolutePathUrlsWithAuthorNameVersionAndModule
                 |> List.map
                     (\url ->

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -11,6 +11,8 @@ parseExternalPackageLinkTest =
         [ describe "URLs with author and name"
             ([ "https://package.elm-lang.org/packages/elm/regex"
              , "https://package.elm-lang.org/packages/elm/regex/"
+             , "http://package.elm-lang.org/packages/elm/regex"
+             , "http://package.elm-lang.org/packages/elm/regex/"
              ]
                 |> List.map
                     (\url ->
@@ -53,6 +55,8 @@ parseExternalPackageLinkTest =
         , describe "URLs with author, name and version"
             ([ "https://package.elm-lang.org/packages/elm/regex/1.1.1"
              , "https://package.elm-lang.org/packages/elm/regex/1.1.1/"
+             , "http://package.elm-lang.org/packages/elm/regex/1.1.1"
+             , "http://package.elm-lang.org/packages/elm/regex/1.1.1/"
              ]
                 |> List.map
                     (\url ->
@@ -94,6 +98,7 @@ parseExternalPackageLinkTest =
             )
         , describe "URLs with author, name, version and module"
             ([ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex"
+             , "http://package.elm-lang.org/packages/elm/regex/1.1.1/Regex"
              ]
                 |> List.map
                     (\url ->
@@ -134,6 +139,7 @@ parseExternalPackageLinkTest =
             )
         , describe "URLs with author, name, version, module and section"
             ([ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
+             , "http://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
              ]
                 |> List.map
                     (\url ->

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -1,12 +1,12 @@
-module Docs.Utils.LinkTest exposing (urlToExternalPackageReferenceTest)
+module Docs.Utils.LinkTest exposing (parseExternalPackageUrlTest)
 
-import Docs.Utils.Link exposing (ExternalPackageReference(..), urlToExternalPackageReference)
+import Docs.Utils.Link exposing (FileTarget(..), SubTarget(..), parseExternalPackageUrl)
 import Expect
 import Test exposing (Test, describe, test)
 
 
-urlToExternalPackageReferenceTest : Test
-urlToExternalPackageReferenceTest =
+parseExternalPackageUrlTest : Test
+parseExternalPackageUrlTest =
     let
         urlsWithAuthorAndName =
             [ "https://package.elm-lang.org/packages/elm/regex"
@@ -42,29 +42,27 @@ urlToExternalPackageReferenceTest =
             , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex"
             , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex#replace"
             , "https://package.elm-lang.org/packages/elm/"
-            , "https://package.elm-lang.org/packages/elm/regex/1.1.1/#replace"
             , "ftp://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
             , "/wrong/elm/regex"
             , "/wrong/elm/regex/1.1.1/"
             , "/wrong/elm/regex/1.1.1/Regex"
             , "/wrong/elm/regex/1.1.1/Regex#replace"
             , "/packages/elm/"
-            , "/packages/elm/regex/1.1.1/#replace"
             ]
     in
-    describe "urlToExternalPackageReference"
+    describe "parseExternalPackageUrl"
         [ describe "URLs with author and name"
             (urlsWithAuthorAndName
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                urlToExternalPackageReference url
+                                parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (ExternalPackageVersionSelectionReference
-                                                { author = "elm"
-                                                , name = "regex"
+                                            (PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = VersionsSubTarget
                                                 }
                                             )
                                         )
@@ -76,13 +74,12 @@ urlToExternalPackageReferenceTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                urlToExternalPackageReference url
+                                parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (ExternalPackageVersionReference
-                                                { author = "elm"
-                                                , name = "regex"
-                                                , version = "1.1.1"
+                                            (PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = ReadmeSubTarget "1.1.1"
                                                 }
                                             )
                                         )
@@ -94,14 +91,12 @@ urlToExternalPackageReferenceTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                urlToExternalPackageReference url
+                                parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (ExternalPackageSectionReference
-                                                { author = "elm"
-                                                , name = "regex"
-                                                , version = "1.1.1"
-                                                , section = "Regex"
+                                            (PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
                                                 }
                                             )
                                         )
@@ -113,14 +108,12 @@ urlToExternalPackageReferenceTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                urlToExternalPackageReference url
+                                parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (ExternalPackageSectionReference
-                                                { author = "elm"
-                                                , name = "regex"
-                                                , version = "1.1.1"
-                                                , section = "Regex#replace"
+                                            (PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
                                                 }
                                             )
                                         )
@@ -132,7 +125,7 @@ urlToExternalPackageReferenceTest =
                     (\url ->
                         test ("should fail to parse: " ++ url) <|
                             \_ ->
-                                urlToExternalPackageReference url
+                                parseExternalPackageUrl url
                                     |> Expect.equal Nothing
                     )
             )

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -1,12 +1,12 @@
-module Docs.Utils.LinkTest exposing (parseExternalPackageUrlTest)
+module Docs.Utils.LinkTest exposing (parseExternalPackageLinkTest)
 
-import Docs.Utils.Link exposing (FileTarget(..), SubTarget(..), parseExternalPackageUrl)
+import Docs.Utils.Link exposing (FileTarget(..), SubTarget(..), parseExternalPackageLink)
 import Expect
 import Test exposing (Test, describe, test)
 
 
-parseExternalPackageUrlTest : Test
-parseExternalPackageUrlTest =
+parseExternalPackageLinkTest : Test
+parseExternalPackageLinkTest =
     let
         urlsWithAuthorAndName =
             [ "https://package.elm-lang.org/packages/elm/regex"
@@ -62,14 +62,14 @@ parseExternalPackageUrlTest =
             , "/packages/elm/"
             ]
     in
-    describe "parseExternalPackageUrl"
+    describe "parseExternalPackageLink"
         [ describe "URLs with author and name"
             (urlsWithAuthorAndName
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -88,7 +88,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -107,7 +107,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -126,7 +126,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -145,7 +145,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -164,7 +164,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -183,7 +183,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -202,7 +202,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal
                                         (Just
                                             { fileTarget =
@@ -221,7 +221,7 @@ parseExternalPackageUrlTest =
                     (\url ->
                         test ("should fail to parse: " ++ url) <|
                             \_ ->
-                                parseExternalPackageUrl url
+                                parseExternalPackageLink url
                                     |> Expect.equal Nothing
                     )
             )

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -8,39 +8,39 @@ import Test exposing (Test, describe, test)
 parseExternalPackageLinkTest : Test
 parseExternalPackageLinkTest =
     let
-        urlsWithAuthorAndName =
+        urlsWithAuthorName =
             [ "https://package.elm-lang.org/packages/elm/regex"
             , "https://package.elm-lang.org/packages/elm/regex/"
             ]
 
-        absolutePathUrlsWithAuthorAndName =
+        absolutePathUrlsWithAuthorName =
             [ "/packages/elm/regex"
             , "/packages/elm/regex/"
             ]
 
-        urlsWithAuthorNameAndVersion =
+        urlsWithAuthorNameVersion =
             [ "https://package.elm-lang.org/packages/elm/regex/1.1.1"
             , "https://package.elm-lang.org/packages/elm/regex/1.1.1/"
             ]
 
-        absolutePathUrlsWithAuthorNameAndVersion =
+        absolutePathUrlsWithAuthorNameVersion =
             [ "/packages/elm/regex/1.1.1"
             , "/packages/elm/regex/1.1.1/"
             ]
 
-        urlsWithAuthorNameVersionAndModule =
+        urlsWithAuthorNameVersionModule =
             [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex"
             ]
 
-        absolutePathUrlsWithAuthorNameVersionAndModule =
+        absolutePathUrlsWithAuthorNameVersionModule =
             [ "/packages/elm/regex/1.1.1/Regex"
             ]
 
-        urlsWithAuthorNameVersionModuleAndSection =
+        urlsWithAuthorNameVersionModuleSection =
             [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
             ]
 
-        absolutePathUrlsWithAuthorNameVersionModuleAndSection =
+        absolutePathUrlsWithAuthorNameVersionModuleSection =
             [ "/packages/elm/regex/1.1.1/Regex#replace"
             ]
 
@@ -64,7 +64,7 @@ parseExternalPackageLinkTest =
     in
     describe "parseExternalPackageLink"
         [ describe "URLs with author and name"
-            (urlsWithAuthorAndName
+            (urlsWithAuthorName
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -83,7 +83,7 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author and name"
-            (absolutePathUrlsWithAuthorAndName
+            (absolutePathUrlsWithAuthorName
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -102,7 +102,7 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "URLs with author, name and version"
-            (urlsWithAuthorNameAndVersion
+            (urlsWithAuthorNameVersion
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -121,7 +121,7 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author, name and version"
-            (absolutePathUrlsWithAuthorNameAndVersion
+            (absolutePathUrlsWithAuthorNameVersion
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -140,7 +140,7 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "URLs with author, name, version and module"
-            (urlsWithAuthorNameVersionAndModule
+            (urlsWithAuthorNameVersionModule
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -159,7 +159,7 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author, name, version and module"
-            (absolutePathUrlsWithAuthorNameVersionAndModule
+            (absolutePathUrlsWithAuthorNameVersionModule
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -178,7 +178,7 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "URLs with author, name, version, module and section"
-            (urlsWithAuthorNameVersionModuleAndSection
+            (urlsWithAuthorNameVersionModuleSection
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -197,7 +197,7 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author, name, version, module and section"
-            (absolutePathUrlsWithAuthorNameVersionModuleAndSection
+            (absolutePathUrlsWithAuthorNameVersionModuleSection
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -1,0 +1,45 @@
+module Docs.Utils.LinkTest exposing (packageLinkParserTest)
+
+import Docs.Utils.Link exposing (packageLinkParser)
+import Expect
+import Parser exposing (Parser)
+import Test exposing (Test, describe, test)
+
+
+packageLinkParserTest : Test
+packageLinkParserTest =
+    let
+        validUrls =
+            [ "/packages/elm/regex/latest/Regex"
+            , "/packages/elm/regex/latest/Regex#Regex"
+            , "/packages/elm/regex/latest/Regex#replace"
+            , "/packages/mdgriffith/elm-ui/latest/Element-Background#image"
+            , "/packages/mdgriffith/elm-ui/1.1.7/Element-Background"
+            , "/packages/mdgriffith/elm-ui"
+            ]
+    in
+    describe "packageLinkParser"
+        (validUrls
+            |> List.map
+                (\url ->
+                    test ("should parse absolute-path URL: " ++ url) <|
+                        \_ ->
+                            Parser.run packageLinkParser url
+                                |> isOk
+                                |> Expect.equal True
+                )
+        )
+
+
+
+-- UTILS
+
+
+isOk : Result x a -> Bool
+isOk result =
+    case result of
+        Ok _ ->
+            True
+
+        Err _ ->
+            False

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -16,35 +16,76 @@ urlToExternalPackageReferenceTest =
             ]
 
         urlsWithAuthorNameAndVersion =
-            [ "/packages/elm/regex/latest"
+            [ "https://package.elm-lang.org/packages/elm/regex/latest"
+            , "https://package.elm-lang.org/packages/elm/regex/latest/"
+            , "https://package.elm-lang.org/packages/elm/regex/1.1.1"
+            , "https://package.elm-lang.org/packages/elm/regex/1.1.1/"
+            , "/packages/elm/regex/latest"
             , "/packages/elm/regex/latest/"
             , "/packages/elm/regex/1.1.1"
             , "/packages/elm/regex/1.1.1/"
             ]
 
-        other =
-            [ "/packages/elm/regex/latest/Regex"
-            , "/packages/elm/regex/latest/Regex#Regex"
+        urlsWithAuthorNameVersionAndSection =
+            [ "https://package.elm-lang.org/packages/elm/regex/latest/Regex#replace"
+            , "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
             , "/packages/elm/regex/latest/Regex#replace"
-            , "/packages/mdgriffith/elm-ui/latest/Element-Background#image"
-            , "/packages/mdgriffith/elm-ui/1.1.7/Element-Background"
-            , "/packages/mdgriffith/elm-ui"
+            , "/packages/elm/regex/1.1.1/Regex#replace"
             ]
     in
     describe "urlToExternalPackageReference"
-        (urlsWithAuthorAndName
-            |> List.map
-                (\url ->
-                    test ("should parse URLs with author and name: " ++ url) <|
-                        \_ ->
-                            urlToExternalPackageReference url
-                                |> Expect.equal
-                                    (Just
-                                        (ExternalPackageVersionSelectionReference
-                                            { author = "elm"
-                                            , name = "regex"
-                                            }
+        [ describe "URLs with author and name"
+            (urlsWithAuthorAndName
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                urlToExternalPackageReference url
+                                    |> Expect.equal
+                                        (Just
+                                            (ExternalPackageVersionSelectionReference
+                                                { author = "elm"
+                                                , name = "regex"
+                                                }
+                                            )
                                         )
-                                    )
-                )
-        )
+                    )
+            )
+        , describe "URLs with author, name and version"
+            (urlsWithAuthorNameAndVersion
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                urlToExternalPackageReference url
+                                    |> Expect.equal
+                                        (Just
+                                            (ExternalPackageVersionReference
+                                                { author = "elm"
+                                                , name = "regex"
+                                                , version = "1.1.1"
+                                                }
+                                            )
+                                        )
+                    )
+            )
+        , describe "URLs with author, name, version and section"
+            (urlsWithAuthorNameVersionAndSection
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                urlToExternalPackageReference url
+                                    |> Expect.equal
+                                        (Just
+                                            (ExternalPackageSectionReference
+                                                { author = "elm"
+                                                , name = "regex"
+                                                , version = "1.1.1"
+                                                , section = "Regex#replace"
+                                                }
+                                            )
+                                        )
+                    )
+            )
+        ]

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -1,6 +1,6 @@
 module Docs.Utils.LinkTest exposing (urlToExternalPackageReferenceTest)
 
-import Docs.Utils.Link exposing (urlToExternalPackageReference)
+import Docs.Utils.Link exposing (ExternalPackageReference(..), urlToExternalPackageReference)
 import Expect
 import Test exposing (Test, describe, test)
 
@@ -9,7 +9,9 @@ urlToExternalPackageReferenceTest : Test
 urlToExternalPackageReferenceTest =
     let
         urlsWithAuthorAndName =
-            [ "/packages/elm/regex"
+            [ "https://package.elm-lang.org/packages/elm/regex"
+            , "https://package.elm-lang.org/packages/elm/regex/"
+            , "/packages/elm/regex"
             , "/packages/elm/regex/"
             ]
 
@@ -31,13 +33,18 @@ urlToExternalPackageReferenceTest =
     in
     describe "urlToExternalPackageReference"
         (urlsWithAuthorAndName
-            ++ urlsWithAuthorNameAndVersion
-            ++ other
             |> List.map
                 (\url ->
-                    test ("should parse absolute-path URL: " ++ url) <|
+                    test ("should parse URLs with author and name: " ++ url) <|
                         \_ ->
                             urlToExternalPackageReference url
-                                |> Expect.notEqual Nothing
+                                |> Expect.equal
+                                    (Just
+                                        (ExternalPackageVersionSelectionReference
+                                            { author = "elm"
+                                            , name = "regex"
+                                            }
+                                        )
+                                    )
                 )
         )

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -16,20 +16,19 @@ urlToExternalPackageReferenceTest =
             ]
 
         urlsWithAuthorNameAndVersion =
-            [ "https://package.elm-lang.org/packages/elm/regex/latest"
-            , "https://package.elm-lang.org/packages/elm/regex/latest/"
-            , "https://package.elm-lang.org/packages/elm/regex/1.1.1"
+            [ "https://package.elm-lang.org/packages/elm/regex/1.1.1"
             , "https://package.elm-lang.org/packages/elm/regex/1.1.1/"
-            , "/packages/elm/regex/latest"
-            , "/packages/elm/regex/latest/"
             , "/packages/elm/regex/1.1.1"
             , "/packages/elm/regex/1.1.1/"
             ]
 
-        urlsWithAuthorNameVersionAndSection =
-            [ "https://package.elm-lang.org/packages/elm/regex/latest/Regex#replace"
-            , "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
-            , "/packages/elm/regex/latest/Regex#replace"
+        urlsWithAuthorNameVersionAndModule =
+            [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex"
+            , "/packages/elm/regex/1.1.1/Regex"
+            ]
+
+        urlsWithAuthorNameVersionModuleAndSection =
+            [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
             , "/packages/elm/regex/1.1.1/Regex#replace"
             ]
     in
@@ -70,7 +69,26 @@ urlToExternalPackageReferenceTest =
                     )
             )
         , describe "URLs with author, name, version and section"
-            (urlsWithAuthorNameVersionAndSection
+            (urlsWithAuthorNameVersionAndModule
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                urlToExternalPackageReference url
+                                    |> Expect.equal
+                                        (Just
+                                            (ExternalPackageSectionReference
+                                                { author = "elm"
+                                                , name = "regex"
+                                                , version = "1.1.1"
+                                                , section = "Regex"
+                                                }
+                                            )
+                                        )
+                    )
+            )
+        , describe "URLs with author, name, version, module and section"
+            (urlsWithAuthorNameVersionModuleAndSection
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -1,6 +1,6 @@
 module Docs.Utils.LinkTest exposing (parseExternalPackageUrlTest)
 
-import Docs.Utils.Link exposing (FileTarget(..), SubTarget(..), parseExternalPackageUrl)
+import Docs.Utils.Link exposing (FileTarget(..), LinkStartsWith(..), SubTarget(..), parseExternalPackageUrl)
 import Expect
 import Test exposing (Test, describe, test)
 
@@ -60,10 +60,11 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (PackagesTarget
+                                            ( PackagesTarget
                                                 { name = "elm/regex"
                                                 , subTarget = VersionsSubTarget
                                                 }
+                                            , OtherLinkStart
                                             )
                                         )
                     )
@@ -77,10 +78,11 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (PackagesTarget
+                                            ( PackagesTarget
                                                 { name = "elm/regex"
                                                 , subTarget = ReadmeSubTarget "1.1.1"
                                                 }
+                                            , OtherLinkStart
                                             )
                                         )
                     )
@@ -94,10 +96,11 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (PackagesTarget
+                                            ( PackagesTarget
                                                 { name = "elm/regex"
                                                 , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
                                                 }
+                                            , OtherLinkStart
                                             )
                                         )
                     )
@@ -111,10 +114,11 @@ parseExternalPackageUrlTest =
                                 parseExternalPackageUrl url
                                     |> Expect.equal
                                         (Just
-                                            (PackagesTarget
+                                            ( PackagesTarget
                                                 { name = "elm/regex"
                                                 , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
                                                 }
+                                            , OtherLinkStart
                                             )
                                         )
                     )

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -11,25 +11,37 @@ parseExternalPackageUrlTest =
         urlsWithAuthorAndName =
             [ "https://package.elm-lang.org/packages/elm/regex"
             , "https://package.elm-lang.org/packages/elm/regex/"
-            , "/packages/elm/regex"
+            ]
+
+        absolutePathUrlsWithAuthorAndName =
+            [ "/packages/elm/regex"
             , "/packages/elm/regex/"
             ]
 
         urlsWithAuthorNameAndVersion =
             [ "https://package.elm-lang.org/packages/elm/regex/1.1.1"
             , "https://package.elm-lang.org/packages/elm/regex/1.1.1/"
-            , "/packages/elm/regex/1.1.1"
+            ]
+
+        absolutePathUrlsWithAuthorNameAndVersion =
+            [ "/packages/elm/regex/1.1.1"
             , "/packages/elm/regex/1.1.1/"
             ]
 
         urlsWithAuthorNameVersionAndModule =
             [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex"
-            , "/packages/elm/regex/1.1.1/Regex"
+            ]
+
+        absolutePathUrlsWithAuthorNameVersionAndModule =
+            [ "/packages/elm/regex/1.1.1/Regex"
             ]
 
         urlsWithAuthorNameVersionModuleAndSection =
             [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
-            , "/packages/elm/regex/1.1.1/Regex#replace"
+            ]
+
+        absolutePathUrlsWithAuthorNameVersionModuleAndSection =
+            [ "/packages/elm/regex/1.1.1/Regex#replace"
             ]
 
         invalidPackageUrls =
@@ -69,6 +81,24 @@ parseExternalPackageUrlTest =
                                         )
                     )
             )
+        , describe "Absolute-path URLs with author and name"
+            (absolutePathUrlsWithAuthorAndName
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                parseExternalPackageUrl url
+                                    |> Expect.equal
+                                        (Just
+                                            ( PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = VersionsSubTarget
+                                                }
+                                            , LinkStartsWithSlash
+                                            )
+                                        )
+                    )
+            )
         , describe "URLs with author, name and version"
             (urlsWithAuthorNameAndVersion
                 |> List.map
@@ -83,6 +113,24 @@ parseExternalPackageUrlTest =
                                                 , subTarget = ReadmeSubTarget "1.1.1"
                                                 }
                                             , OtherLinkStart
+                                            )
+                                        )
+                    )
+            )
+        , describe "Absolute-path URLs with author, name and version"
+            (absolutePathUrlsWithAuthorNameAndVersion
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                parseExternalPackageUrl url
+                                    |> Expect.equal
+                                        (Just
+                                            ( PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = ReadmeSubTarget "1.1.1"
+                                                }
+                                            , LinkStartsWithSlash
                                             )
                                         )
                     )
@@ -105,6 +153,24 @@ parseExternalPackageUrlTest =
                                         )
                     )
             )
+        , describe "Absolute-path URLs with author, name, version and section"
+            (absolutePathUrlsWithAuthorNameVersionAndModule
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                parseExternalPackageUrl url
+                                    |> Expect.equal
+                                        (Just
+                                            ( PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
+                                                }
+                                            , LinkStartsWithSlash
+                                            )
+                                        )
+                    )
+            )
         , describe "URLs with author, name, version, module and section"
             (urlsWithAuthorNameVersionModuleAndSection
                 |> List.map
@@ -119,6 +185,24 @@ parseExternalPackageUrlTest =
                                                 , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
                                                 }
                                             , OtherLinkStart
+                                            )
+                                        )
+                    )
+            )
+        , describe "Absolute-path URLs with author, name, version, module and section"
+            (absolutePathUrlsWithAuthorNameVersionModuleAndSection
+                |> List.map
+                    (\url ->
+                        test ("should parse: " ++ url) <|
+                            \_ ->
+                                parseExternalPackageUrl url
+                                    |> Expect.equal
+                                        (Just
+                                            ( PackagesTarget
+                                                { name = "elm/regex"
+                                                , subTarget = ModuleSubTarget "1.1.1" [ "Regex" ]
+                                                }
+                                            , LinkStartsWithSlash
                                             )
                                         )
                     )

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -31,6 +31,26 @@ urlToExternalPackageReferenceTest =
             [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
             , "/packages/elm/regex/1.1.1/Regex#replace"
             ]
+
+        invalidPackageUrls =
+            [ "https://www.example.com/packages/elm/regex"
+            , "https://www.example.com/packages/elm/regex/1.1.1/"
+            , "https://www.example.com/packages/elm/regex/1.1.1/Regex"
+            , "https://www.example.com/packages/elm/regex/1.1.1/Regex#replace"
+            , "https://package.elm-lang.org/wrong/elm/regex"
+            , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/"
+            , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex"
+            , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex#replace"
+            , "https://package.elm-lang.org/packages/elm/"
+            , "https://package.elm-lang.org/packages/elm/regex/1.1.1/#replace"
+            , "ftp://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
+            , "/wrong/elm/regex"
+            , "/wrong/elm/regex/1.1.1/"
+            , "/wrong/elm/regex/1.1.1/Regex"
+            , "/wrong/elm/regex/1.1.1/Regex#replace"
+            , "/packages/elm/"
+            , "/packages/elm/regex/1.1.1/#replace"
+            ]
     in
     describe "urlToExternalPackageReference"
         [ describe "URLs with author and name"
@@ -104,6 +124,16 @@ urlToExternalPackageReferenceTest =
                                                 }
                                             )
                                         )
+                    )
+            )
+        , describe "Invalid package URLs"
+            (invalidPackageUrls
+                |> List.map
+                    (\url ->
+                        test ("should fail to parse: " ++ url) <|
+                            \_ ->
+                                urlToExternalPackageReference url
+                                    |> Expect.equal Nothing
                     )
             )
         ]

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -7,64 +7,11 @@ import Test exposing (Test, describe, test)
 
 parseExternalPackageLinkTest : Test
 parseExternalPackageLinkTest =
-    let
-        urlsWithAuthorName =
-            [ "https://package.elm-lang.org/packages/elm/regex"
-            , "https://package.elm-lang.org/packages/elm/regex/"
-            ]
-
-        absolutePathUrlsWithAuthorName =
-            [ "/packages/elm/regex"
-            , "/packages/elm/regex/"
-            ]
-
-        urlsWithAuthorNameVersion =
-            [ "https://package.elm-lang.org/packages/elm/regex/1.1.1"
-            , "https://package.elm-lang.org/packages/elm/regex/1.1.1/"
-            ]
-
-        absolutePathUrlsWithAuthorNameVersion =
-            [ "/packages/elm/regex/1.1.1"
-            , "/packages/elm/regex/1.1.1/"
-            ]
-
-        urlsWithAuthorNameVersionModule =
-            [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex"
-            ]
-
-        absolutePathUrlsWithAuthorNameVersionModule =
-            [ "/packages/elm/regex/1.1.1/Regex"
-            ]
-
-        urlsWithAuthorNameVersionModuleSection =
-            [ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
-            ]
-
-        absolutePathUrlsWithAuthorNameVersionModuleSection =
-            [ "/packages/elm/regex/1.1.1/Regex#replace"
-            ]
-
-        invalidPackageUrls =
-            [ "https://www.example.com/packages/elm/regex"
-            , "https://www.example.com/packages/elm/regex/1.1.1/"
-            , "https://www.example.com/packages/elm/regex/1.1.1/Regex"
-            , "https://www.example.com/packages/elm/regex/1.1.1/Regex#replace"
-            , "https://package.elm-lang.org/wrong/elm/regex"
-            , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/"
-            , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex"
-            , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex#replace"
-            , "https://package.elm-lang.org/packages/elm/"
-            , "ftp://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
-            , "/wrong/elm/regex"
-            , "/wrong/elm/regex/1.1.1/"
-            , "/wrong/elm/regex/1.1.1/Regex"
-            , "/wrong/elm/regex/1.1.1/Regex#replace"
-            , "/packages/elm/"
-            ]
-    in
     describe "parseExternalPackageLink"
         [ describe "URLs with author and name"
-            (urlsWithAuthorName
+            ([ "https://package.elm-lang.org/packages/elm/regex"
+             , "https://package.elm-lang.org/packages/elm/regex/"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -83,7 +30,9 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author and name"
-            (absolutePathUrlsWithAuthorName
+            ([ "/packages/elm/regex"
+             , "/packages/elm/regex/"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -102,7 +51,9 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "URLs with author, name and version"
-            (urlsWithAuthorNameVersion
+            ([ "https://package.elm-lang.org/packages/elm/regex/1.1.1"
+             , "https://package.elm-lang.org/packages/elm/regex/1.1.1/"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -121,7 +72,9 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author, name and version"
-            (absolutePathUrlsWithAuthorNameVersion
+            ([ "/packages/elm/regex/1.1.1"
+             , "/packages/elm/regex/1.1.1/"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -140,7 +93,8 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "URLs with author, name, version and module"
-            (urlsWithAuthorNameVersionModule
+            ([ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -159,7 +113,8 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author, name, version and module"
-            (absolutePathUrlsWithAuthorNameVersionModule
+            ([ "/packages/elm/regex/1.1.1/Regex"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -178,7 +133,8 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "URLs with author, name, version, module and section"
-            (urlsWithAuthorNameVersionModuleSection
+            ([ "https://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -197,7 +153,8 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Absolute-path URLs with author, name, version, module and section"
-            (absolutePathUrlsWithAuthorNameVersionModuleSection
+            ([ "/packages/elm/regex/1.1.1/Regex#replace"
+             ]
                 |> List.map
                     (\url ->
                         test ("should parse: " ++ url) <|
@@ -216,7 +173,22 @@ parseExternalPackageLinkTest =
                     )
             )
         , describe "Invalid package URLs"
-            (invalidPackageUrls
+            ([ "https://www.example.com/packages/elm/regex"
+             , "https://www.example.com/packages/elm/regex/1.1.1/"
+             , "https://www.example.com/packages/elm/regex/1.1.1/Regex"
+             , "https://www.example.com/packages/elm/regex/1.1.1/Regex#replace"
+             , "https://package.elm-lang.org/wrong/elm/regex"
+             , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/"
+             , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex"
+             , "https://package.elm-lang.org/wrong/elm/regex/1.1.1/Regex#replace"
+             , "https://package.elm-lang.org/packages/elm/"
+             , "ftp://package.elm-lang.org/packages/elm/regex/1.1.1/Regex#replace"
+             , "/wrong/elm/regex"
+             , "/wrong/elm/regex/1.1.1/"
+             , "/wrong/elm/regex/1.1.1/Regex"
+             , "/wrong/elm/regex/1.1.1/Regex#replace"
+             , "/packages/elm/"
+             ]
                 |> List.map
                     (\url ->
                         test ("should fail to parse: " ++ url) <|

--- a/tests/Docs/Utils/LinkTest.elm
+++ b/tests/Docs/Utils/LinkTest.elm
@@ -1,15 +1,26 @@
-module Docs.Utils.LinkTest exposing (packageLinkParserTest)
+module Docs.Utils.LinkTest exposing (urlToExternalPackageReferenceTest)
 
-import Docs.Utils.Link exposing (packageLinkParser)
+import Docs.Utils.Link exposing (urlToExternalPackageReference)
 import Expect
-import Parser exposing (Parser)
 import Test exposing (Test, describe, test)
 
 
-packageLinkParserTest : Test
-packageLinkParserTest =
+urlToExternalPackageReferenceTest : Test
+urlToExternalPackageReferenceTest =
     let
-        validUrls =
+        urlsWithAuthorAndName =
+            [ "/packages/elm/regex"
+            , "/packages/elm/regex/"
+            ]
+
+        urlsWithAuthorNameAndVersion =
+            [ "/packages/elm/regex/latest"
+            , "/packages/elm/regex/latest/"
+            , "/packages/elm/regex/1.1.1"
+            , "/packages/elm/regex/1.1.1/"
+            ]
+
+        other =
             [ "/packages/elm/regex/latest/Regex"
             , "/packages/elm/regex/latest/Regex#Regex"
             , "/packages/elm/regex/latest/Regex#replace"
@@ -18,28 +29,15 @@ packageLinkParserTest =
             , "/packages/mdgriffith/elm-ui"
             ]
     in
-    describe "packageLinkParser"
-        (validUrls
+    describe "urlToExternalPackageReference"
+        (urlsWithAuthorAndName
+            ++ urlsWithAuthorNameAndVersion
+            ++ other
             |> List.map
                 (\url ->
                     test ("should parse absolute-path URL: " ++ url) <|
                         \_ ->
-                            Parser.run packageLinkParser url
-                                |> isOk
-                                |> Expect.equal True
+                            urlToExternalPackageReference url
+                                |> Expect.notEqual Nothing
                 )
         )
-
-
-
--- UTILS
-
-
-isOk : Result x a -> Bool
-isOk result =
-    case result of
-        Ok _ ->
-            True
-
-        Err _ ->
-            False


### PR DESCRIPTION
Apologies for the near infinite delay! This is the PR promised in [this old issue I wrote](https://github.com/jfmengels/elm-review-documentation/issues/17).

So, one of the reasons it took me this long to send this PR (other than plain procrastination, and being genuinely busy) is because I wasn't able to decide exactly how should behavior change here. In the end though I went back and did what I consider to be the simplest:

- Treat `/`-starting URLs used in links within module documentation just as regular, full URLs linking to the official package repository.
- However, only allow that format for packages, not apps.
- Suggest a fix when used in app docs: `/` → `https://…`.

## Questions

1. The UpToDateReadmeLinks rule uses the same (updated) URL parser and formatter, so it has the same behavior of allowing `/`-starting links of the ReviewLinksAndSections rule, although I would not consider it correct. Should it be expressly disallowed?
2. There is one potential drawback to having these kinds of absolute paths in links in a package's documentation, which is that you can't click them in an editor's on-hover documentation and let it open a browser window for you. However, it also has never worked for links pointing to other sections of the same package's documentation, so you could say package documentation just isn't optimized for this use case. Should we backtrack on this PR? Make it an option?
3. I added elm/url as a dependency, which isn't great but simplifies parsing URLs a great deal over using a regex. Was this wrong?
4. My parser-fu is very weak so I might have screwed up there a bit.